### PR TITLE
Handle Error When Spotify Returns No Content

### DIFF
--- a/yutipy/spotify.py
+++ b/yutipy/spotify.py
@@ -1087,8 +1087,16 @@ class SpotifyAuth:
         except requests.RequestException as e:
             raise NetworkException(f"Network error occurred: {e}")
 
+        if response.status_code == 204:
+            logger.info("Requested user is currently not listening to any music.")
+            return None
         if response.status_code != 200:
-            logger.error(f"Unexpected response: {response.json()}")
+            try:
+                logger.error(f"Unexpected response: {response.json()}")
+            except requests.exceptions.JSONDecodeError:
+                logger.error(
+                    f"Response Code: {response.status_code}, Reason: {response.reason}"
+                )
             return None
 
         response_json = response.json()


### PR DESCRIPTION
- for example, user is not listening to any music.
- it was raising `JSONDecoderError`.