### PR TITLE
Update Docs

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -132,12 +132,6 @@ Generic Exceptions
     :noindex:
     :exclude-members: add_note, args, with_traceback
 
-.. autoclass:: yutipy.exceptions.NetworkException
-    :members:
-    :inherited-members:
-    :noindex:
-    :exclude-members: add_note, args, with_traceback
-
 Service Exceptions
 ------------------
 


### PR DESCRIPTION
- Remove `NetworkException` from api reference as it no longer exists. Removed in 9e84ca433a7b3e143771796143edb75377532055