### PR TITLE
Only Return Activity if Currently Playing

### DIFF
--- a/tests/test_lastfm.py
+++ b/tests/test_lastfm.py
@@ -34,6 +34,7 @@ class MockResponseActivity(BaseResponse):
                             "#text": "Test Album",
                         },
                         "name": "Test Track",
+                        "@attr": {"nowplaying": True},
                         "url": "https://www.last.fm/music/test+track",
                     }
                 ]
@@ -88,7 +89,7 @@ def test_get_currently_playing(lastfm, mock_response_activity):
     assert currently_playing.title == "Test Track"
     assert currently_playing.album_title == "Test Album"
     assert "extralarge" in currently_playing.album_art
-    assert currently_playing.is_playing is False
+    assert currently_playing.is_playing is True
 
 
 def test_get_user_profile(lastfm, mock_response_profile):

--- a/yutipy/lastfm.py
+++ b/yutipy/lastfm.py
@@ -2,6 +2,7 @@ __all__ = ["LastFm", "LastFmException"]
 
 import os
 from dataclasses import asdict
+from time import time
 from pprint import pprint
 from typing import Optional
 
@@ -140,7 +141,8 @@ class LastFm:
 
         response_json = response.json()
         result = response_json.get("recenttracks", {}).get("track", [])[0]
-        if result:
+        is_playing = result.get("@attr", {}).get("nowplaying", False)
+        if result and is_playing:
             album_art = [
                 img.get("#text")
                 for img in result.get("image", [])
@@ -153,10 +155,10 @@ class LastFm:
                     separate_artists(result.get("artist", {}).get("#text"))
                 ),
                 id=result.get("mbid"),
-                timestamp=result.get("date", {}).get("uts"),
+                timestamp=result.get("date", {}).get("uts") or time(),
                 title=result.get("name"),
                 url=result.get("url"),
-                is_playing=result.get("@attr", {}).get("nowplaying", False),
+                is_playing=is_playing,
             )
         return None
 


### PR DESCRIPTION
- Also, it seems that the timestamp in not about when the playback started, but rather when that track was (first) scrobbled to Lastfm... (°ー°〃)
- And they don't have docs explain the schema, what fields to expect, what field is what, etc. !!! I hate it when they do like this.. like, why even have public api when you don't bother to document it properly  ??? _(:з)∠)_