### PR TITLE
Add Base Clients & Refactor to Avoid Duplication

### DIFF
--- a/tests/test_kkbox.py
+++ b/tests/test_kkbox.py
@@ -20,7 +20,7 @@ def kkbox():
         client_id="test_client_id", client_secret="test_client_secret", defer_load=True
     )
 
-    kkbox_instance._KKBox__get_access_token = mock_get_access_token
+    kkbox_instance._get_access_token = mock_get_access_token
     kkbox_instance.load_token_after_init()
     return kkbox_instance
 
@@ -62,7 +62,7 @@ def mock_response(kkbox, monkeypatch):
     def mock_get(*args, **kwargs):
         return MockResponse()
 
-    monkeypatch.setattr(kkbox._KKBox__session, "get", mock_get)
+    monkeypatch.setattr(kkbox._session, "get", mock_get)
 
 
 def test_search(kkbox, mock_response):

--- a/yutipy/base_clients.py
+++ b/yutipy/base_clients.py
@@ -129,7 +129,6 @@ class BaseClient:
         dict
             The API access token, with additional information such as expires in, etc.
         """
-        print(self._client_id, self._client_secret)
         auth_string = f"{self._client_id}:{self._client_secret}"
         auth_base64 = base64.b64encode(auth_string.encode("utf-8")).decode("utf-8")
 

--- a/yutipy/base_clients.py
+++ b/yutipy/base_clients.py
@@ -1,0 +1,583 @@
+__all__ = ["BaseClient", "BaseAuthClient"]
+
+import base64
+import secrets
+from time import time
+from urllib.parse import urlencode
+
+import requests
+
+from yutipy.exceptions import AuthenticationException, InvalidValueException
+from yutipy.logger import logger
+
+
+class BaseClient:
+    """Base class for Client Credentials grant type/flow."""
+
+    SERVICE_NAME: str
+    ACCESS_TOKEN_URL: str
+
+    def __init__(
+        self,
+        service_name: str,
+        access_token_url: str,
+        client_id: str = None,
+        client_secret: str = None,
+        defer_load: bool = False,
+    ) -> None:
+        """Initializes client (using Client Credentials grant type/flow) and sets up the session.
+
+        Parameters
+        ----------
+        service_name : str
+            The service name class belongs to. For example, "Spotify".
+        access_token_url : str
+            The url endpoint to request access token.
+        """
+
+        self.SERVICE_NAME = service_name
+        self.ACCESS_TOKEN_URL = access_token_url
+
+        self._client_id = client_id
+        self._client_secret = client_secret
+
+        self._defer_load = defer_load
+        self._is_session_closed = False
+        self._normalize_non_english = True
+
+        self._access_token = None
+        self._token_expires_in = None
+        self._token_requested_at = None
+        self._session = requests.Session()
+        self._translation_session = requests.Session()
+
+        if not defer_load:
+            # Attempt to load access token during initialization if not deferred
+            self.load_token_after_init()
+        else:
+            logger.warning(
+                "`defer_load` is set to `True`. Make sure to call `load_token_after_init()`."
+            )
+
+    def __enter__(self):
+        """Enters the runtime context related to this object."""
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        """Exits the runtime context related to this object."""
+        self.close_session()
+
+    def close_session(self) -> None:
+        """Closes the current session(s)."""
+        if not self.is_session_closed:
+            self._session.close()
+            self._translation_session.close()
+            self._is_session_closed = True
+
+    @property
+    def is_session_closed(self) -> bool:
+        """Checks if the session is closed."""
+        return self._is_session_closed
+
+    def load_token_after_init(self) -> None:
+        """
+        Explicitly load the access token after initialization.
+        This is useful when ``defer_load`` is set to ``True`` during initialization.
+        """
+        token_info = None
+        try:
+            token_info = self.load_access_token()
+            if not isinstance(token_info, dict):
+                raise InvalidValueException(
+                    "`load_access_token()` should return a dict."
+                )
+        except NotImplementedError:
+            logger.warning(
+                "`load_access_token` is not implemented. Falling back to in-memory storage and requesting new access token."
+            )
+        finally:
+            if not token_info:
+                token_info = self._get_access_token()
+            self._access_token = token_info.get("access_token")
+            self._token_expires_in = token_info.get("expires_in")
+            self._token_requested_at = token_info.get("requested_at")
+
+            try:
+                self.save_access_token(token_info)
+            except NotImplementedError:
+                logger.warning(
+                    "`save_access_token` is not implemented, falling back to in-memory storage. Access token will not be saved."
+                )
+
+    def _authorization_header(self) -> dict:
+        """
+        Generates the authorization header for API requests.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the Bearer token for authentication.
+        """
+        return {"Authorization": f"Bearer {self._access_token}"}
+
+    def _get_access_token(self) -> dict:
+        """
+        Gets the API access token information.
+
+        Returns
+        -------
+        dict
+            The API access token, with additional information such as expires in, etc.
+        """
+        print(self._client_id, self._client_secret)
+        auth_string = f"{self._client_id}:{self._client_secret}"
+        auth_base64 = base64.b64encode(auth_string.encode("utf-8")).decode("utf-8")
+
+        url = self.ACCESS_TOKEN_URL
+        headers = {
+            "Authorization": f"Basic {auth_base64}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        data = {"grant_type": "client_credentials"}
+
+        try:
+            logger.info(
+                f"Authenticating with {self.SERVICE_NAME} API using Client Credentials grant type."
+            )
+            response = self._session.post(
+                url=url, headers=headers, data=data, timeout=30
+            )
+            logger.debug(f"Authentication response status code: {response.status_code}")
+            response.raise_for_status()
+        except requests.RequestException as e:
+            raise AuthenticationException(
+                f"Something went wrong authenticating with {self.SERVICE_NAME}: {e}"
+            )
+
+        response_json = response.json()
+        response_json["requested_at"] = time()
+        return response_json
+
+    def _refresh_access_token(self) -> None:
+        """Refreshes the token if it has expired."""
+        try:
+            if time() - self._token_requested_at >= self._token_expires_in:
+                token_info = self._get_access_token()
+
+                try:
+                    self.save_access_token(token_info)
+                except NotImplementedError as e:
+                    logger.warning(e)
+
+                self._access_token = token_info.get("access_token")
+                self._token_expires_in = token_info.get("expires_in")
+                self._token_requested_at = token_info.get("requested_at")
+            else:
+                logger.info("The access token is still valid, no need to refresh.")
+        except TypeError:
+            logger.debug(
+                f"token requested at: {self._token_requested_at} | token expires in: {self._token_expires_in}"
+            )
+            logger.info(
+                "Something went wrong while trying to refresh the access token. Set logging level to `DEBUG` to see the issue."
+            )
+
+    def save_access_token(self, token_info: dict) -> None:
+        """
+        Saves the access token and related information.
+
+        This method must be overridden in a subclass to persist the access token and other
+        related information (e.g., expiration time). If not implemented,
+        the access token will not be saved, and it will be requested each time the
+        application restarts.
+
+        Parameters
+        ----------
+        token_info : dict
+            A dictionary containing the access token and related information, such as
+            refresh token, expiration time, etc.
+
+        Raises
+        ------
+        NotImplementedError
+            If the method is not overridden in a subclass.
+        """
+        raise NotImplementedError(
+            "The `save_access_token` method must be overridden in a subclass to save the access token and related information. "
+            "If not implemented, access token information will not be persisted, and users will need to re-authenticate after application restarts."
+        )
+
+    def load_access_token(self) -> dict:
+        """
+        Loads the access token and related information.
+
+        This method must be overridden in a subclass to retrieve the access token and other
+        related information (e.g., expiration time) from persistent storage.
+        If not implemented, the access token will not be loaded, and it will be requested
+        each time the application restarts.
+
+        Returns
+        -------
+        dict | None
+            A dictionary containing the access token and related information, such as
+            refresh token, expiration time, etc., or None if no token is found.
+
+        Raises
+        ------
+        NotImplementedError
+            If the method is not overridden in a subclass.
+        """
+        raise NotImplementedError(
+            "The `load_access_token` method must be overridden in a subclass to load access token and related information. "
+            "If not implemented, access token information will not be loaded, and users will need to re-authenticate after application restarts."
+        )
+
+
+class BaseAuthClient:
+    """Base class for Authorization Code grant type/flow."""
+
+    SERVICE_NAME: str
+    ACCESS_TOKEN_URL: str
+    USER_AUTH_URL: str
+
+    def __init__(
+        self,
+        service_name: str,
+        access_token_url: str,
+        user_auth_url: str,
+        client_id: str,
+        client_secret: str,
+        redirect_uri: str,
+        scopes: str = None,
+        defer_load: bool = False,
+    ):
+        """
+        Initializes client (using Authorization Code grant type/flow) and sets up the session.
+
+        Parameters
+        ----------
+        service_name : str
+            The service name class belongs to. For example, "Spotify".
+        access_token_url : str
+            The url endpoint to request access token.
+        user_auth_url : str
+            The url endpoint for user authentication.
+        """
+
+        self.SERVICE_NAME = service_name
+        self.ACCESS_TOKEN_URL = access_token_url
+        self.USER_AUTH_URL = user_auth_url
+
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._redirect_uri = redirect_uri
+        self._scopes = scopes
+
+        self._defer_load = defer_load
+        self._is_session_closed = False
+
+        self._access_token = None
+        self._refresh_token = None
+        self._token_expires_in = None
+        self._token_requested_at = None
+        self._session = requests.Session()
+
+        if not defer_load:
+            # Attempt to load access token during initialization if not deferred
+            self.load_token_after_init()
+        else:
+            logger.warning(
+                "`defer_load` is set to `True`. Make sure to call `load_token_after_init()`."
+            )
+
+    def __enter__(self):
+        """Enters the runtime context related to this object."""
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        """Exits the runtime context related to this object."""
+        self.close_session()
+
+    def close_session(self) -> None:
+        """Closes the current session(s)."""
+        if not self.is_session_closed:
+            self._session.close()
+            self._is_session_closed = True
+
+    @property
+    def is_session_closed(self) -> bool:
+        """Checks if the session is closed."""
+        return self._is_session_closed
+
+    def load_token_after_init(self):
+        """
+        Explicitly load the access token after initialization.
+        This is useful when ``defer_load`` is set to ``True`` during initialization.
+        """
+        token_info = None
+        try:
+            token_info = self.load_access_token()
+            if not isinstance(token_info, dict):
+                raise InvalidValueException(
+                    "`load_access_token()` should return a dict."
+                )
+        except NotImplementedError:
+            logger.warning(
+                "`load_access_token` is not implemented. Falling back to in-memory storage."
+            )
+        finally:
+            if token_info:
+                self._access_token = token_info.get("access_token")
+                self._refresh_token = token_info.get("refresh_token")
+                self._token_expires_in = token_info.get("expires_in")
+                self._token_requested_at = token_info.get("requested_at")
+            else:
+                logger.warning(
+                    "No access token found during initialization. You must authenticate to obtain a new token."
+                )
+
+    def _authorization_header(self) -> dict:
+        """
+        Generates the authorization header for Spotify API requests.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the Bearer token for authentication.
+        """
+        return {"Authorization": f"Bearer {self._access_token}"}
+
+    def _get_access_token(
+        self,
+        authorization_code: str = None,
+        refresh_token: str = None,
+    ) -> dict:
+        """
+        Gets the API access token information.
+
+        If ``authorization_code`` provided, it will try to get a new access token. Otherwise, if ``refresh_token`` is provided,
+        it will refresh the access token using it and return new access token information.
+
+        Returns
+        -------
+        dict
+            The API access token, with additional information such as expires in, refresh token, etc.
+        """
+        auth_string = f"{self.client_id}:{self.client_secret}"
+        auth_base64 = base64.b64encode(auth_string.encode("utf-8")).decode("utf-8")
+
+        url = self.ACCESS_TOKEN_URL
+        headers = {
+            "Authorization": f"Basic {auth_base64}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        if authorization_code:
+            data = {
+                "grant_type": "authorization_code",
+                "code": authorization_code,
+                "redirect_uri": self.redirect_uri,
+            }
+
+        if refresh_token:
+            data = {
+                "grant_type": "refresh_token",
+                "refresh_token": self._refresh_token,
+            }
+
+        try:
+            logger.info(
+                f"Authenticating with {self.SERVICE_NAME} API using Authorization Code grant type."
+            )
+            response = self._session.post(
+                url=url, headers=headers, data=data, timeout=30
+            )
+            logger.debug(f"Authentication response status code: {response.status_code}")
+            response.raise_for_status()
+        except requests.RequestException as e:
+            raise AuthenticationException(
+                f"Something went wrong authenticating with {self.SERVICE_NAME}: {e}"
+            )
+
+        response_json = response.json()
+        response_json["requested_at"] = time()
+        return response_json
+
+    def _refresh_access_token(self):
+        """Refreshes the token if it has expired."""
+        try:
+            if time() - self._token_requested_at >= self._token_expires_in:
+                token_info = self._get_access_token(refresh_token=self._refresh_token)
+
+                try:
+                    self.save_access_token(token_info)
+                except NotImplementedError as e:
+                    logger.warning(e)
+
+                self._access_token = token_info.get("access_token")
+                self._refresh_token = token_info.get("refresh_token")
+                self._token_expires_in = token_info.get("expires_in")
+                self._token_requested_at = token_info.get("requested_at")
+
+            else:
+                logger.info("The access token is still valid, no need to refresh.")
+        except TypeError:
+            logger.debug(
+                f"token requested at: {self._token_requested_at} | token expires in: {self._token_expires_in}"
+            )
+            logger.warning(
+                "Something went wrong while trying to refresh the access token. Set logging level to `DEBUG` to see the issue."
+            )
+
+    @staticmethod
+    def generate_state() -> str:
+        """
+        Generates a random state string for use in OAuth 2.0 authorization.
+
+        This method creates a cryptographically secure, URL-safe string that can be used
+        to prevent cross-site request forgery (CSRF) attacks during the authorization process.
+
+        Returns
+        -------
+        str
+            A random URL-safe string to be used as the state parameter in OAuth 2.0.
+        """
+        return secrets.token_urlsafe()
+
+    def get_authorization_url(
+        self, state: str = None, show_dialog: bool = False
+    ) -> str:
+        """
+        Constructs the Spotify authorization URL for user authentication.
+
+        This method generates a URL that can be used to redirect users to Spotify's
+        authorization page for user authentication.
+
+        Parameters
+        ----------
+        state : str, optional
+            A random string to maintain state between the request and callback.
+            If not provided, no state parameter is included.
+
+            You may use :meth:`SpotifyAuth.generate_state` method to generate one.
+        show_dialog : bool, optional
+            Whether or not to force the user to approve the app again if they’ve already done so.
+            If ``False`` (default), a user who has already approved the application may be automatically
+            redirected to the URI specified by redirect_uri. If ``True``, the user will not be automatically
+            redirected and will have to approve the app again.
+
+        Returns
+        -------
+        str
+            The full authorization URL to redirect users for Spotify authentication.
+        """
+        payload = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+        }
+
+        if self._scopes:
+            payload["scope"] = self._scopes
+
+        if show_dialog:
+            payload["show_dialog"] = show_dialog
+
+        if state:
+            payload["state"] = state
+
+        return f"{self.USER_AUTH_URL}?{urlencode(payload)}"
+
+    def save_access_token(self, token_info: dict) -> None:
+        """
+        Saves the access token and related information.
+
+        This method must be overridden in a subclass to persist the access token and other
+        related information (e.g., refresh token, expiration time). If not implemented,
+        the access token will not be saved, and users will need to re-authenticate after
+        application restarts.
+
+        Parameters
+        ----------
+        token_info : dict
+            A dictionary containing the access token and related information, such as
+            refresh token, expiration time, etc.
+
+        Raises
+        ------
+        NotImplementedError
+            If the method is not overridden in a subclass.
+        """
+        raise NotImplementedError(
+            "The `save_access_token` method must be overridden in a subclass to save the access token and related information. "
+            "If not implemented, access token information will not be persisted, and users will need to re-authenticate after application restarts."
+        )
+
+    def load_access_token(self) -> dict:
+        """
+        Loads the access token and related information.
+
+        This method must be overridden in a subclass to retrieve the access token and other
+        related information (e.g., refresh token, expiration time) from persistent storage.
+        If not implemented, the access token will not be loaded, and users will need to
+        re-authenticate after application restarts.
+
+        Returns
+        -------
+        dict | None
+            A dictionary containing the access token and related information, such as
+            refresh token, expiration time, etc., or None if no token is found.
+
+        Raises
+        ------
+        NotImplementedError
+            If the method is not overridden in a subclass.
+        """
+        raise NotImplementedError(
+            "The `load_access_token` method must be overridden in a subclass to load access token and related information. "
+            "If not implemented, access token information will not be loaded, and users will need to re-authenticate after application restarts."
+        )
+
+    def callback_handler(self, code, state, expected_state):
+        """
+        Handles the callback phase of the OAuth 2.0 authorization process.
+
+        This method processes the authorization code and state returned by Spotify after the user
+        has granted permission. It validates the state to prevent CSRF attacks, exchanges the
+        authorization code for an access token, and saves the token for future use.
+
+        Parameters
+        ----------
+        code : str
+            The authorization code returned by Spotify after user authorization.
+        state : str
+            The state parameter returned by Spotify to ensure the request's integrity.
+        expected_state : str
+            The original state parameter sent during the authorization request, used to validate the response.
+
+        Raises
+        ------
+        SpotifyAuthException
+            If the returned state does not match the expected state.
+
+        Notes
+        -----
+        - This method can be used in a web application (e.g., Flask) in the `/callback` route to handle
+          successful authorization.
+        - Ensure that the ``save_access_token`` and ``load_access_token`` methods are implemented in a subclass
+          if token persistence is required.
+        """
+        if state != expected_state:
+            raise AuthenticationException("state does not match!")
+
+        token_info = self._get_access_token(authorization_code=code)
+
+        self._access_token = token_info.get("access_token")
+        self._refresh_token = token_info.get("refresh_token")
+        self._token_expires_in = token_info.get("expires_in")
+        self._token_requested_at = token_info.get("requested_at")
+
+        try:
+            self.save_access_token(token_info)
+        except NotImplementedError as e:
+            logger.warning(e)

--- a/yutipy/itunes.py
+++ b/yutipy/itunes.py
@@ -2,22 +2,14 @@ __all__ = ["Itunes", "ItunesException"]
 
 from datetime import datetime
 from pprint import pprint
-from typing import Dict, Optional
+from typing import Optional
 
 import requests
 
-from yutipy.exceptions import (
-    InvalidResponseException,
-    InvalidValueException,
-    ItunesException
-)
-from yutipy.models import MusicInfo
-from yutipy.utils.helpers import (
-    are_strings_similar,
-    guess_album_type,
-    is_valid_string,
-)
+from yutipy.exceptions import InvalidValueException, ItunesException
 from yutipy.logger import logger
+from yutipy.models import MusicInfo
+from yutipy.utils.helpers import are_strings_similar, guess_album_type, is_valid_string
 
 
 class Itunes:
@@ -25,13 +17,13 @@ class Itunes:
 
     def __init__(self) -> None:
         """Initializes the iTunes class and sets up the session."""
-        self.__session = requests.Session()
         self.api_url = "https://itunes.apple.com"
-        self._is_session_closed = False
         self.normalize_non_english = True
+        self._is_session_closed = False
+        self.__session = requests.Session()
         self.__translation_session = requests.Session()
 
-    def __enter__(self) -> "Itunes":
+    def __enter__(self):
         """Enters the runtime context related to this object."""
         return self
 
@@ -99,18 +91,15 @@ class Itunes:
                 logger.debug(f"Response status code: {response.status_code}")
                 response.raise_for_status()
             except requests.RequestException as e:
-                logger.warning(f"Network error while searching iTunes: {e}")
+                logger.warning(f"Unexpected error while searching iTunes: {e}")
                 return None
-            except Exception as e:
-                logger.exception(f"Unexpected error while searching iTunes: {e}")
-                raise ItunesException(f"An error occurred while searching iTunes: {e}")
 
             try:
                 logger.debug(f"Parsing response JSON: {response.json()}")
                 result = response.json()["results"]
             except (IndexError, KeyError, ValueError) as e:
                 logger.warning(f"Invalid response structure from iTunes: {e}")
-                raise InvalidResponseException(f"Invalid response received: {e}")
+                return None
 
             music_info = self._parse_result(artist, song, result)
             if music_info:
@@ -227,6 +216,7 @@ class Itunes:
 
 if __name__ == "__main__":
     import logging
+
     from yutipy.logger import enable_logging
 
     enable_logging(level=logging.DEBUG)

--- a/yutipy/kkbox.py
+++ b/yutipy/kkbox.py
@@ -1,20 +1,15 @@
 __all__ = ["KKBox", "KKBoxException"]
 
-import base64
 import os
 from dataclasses import asdict
 from pprint import pprint
-from time import time
-from typing import Optional, Union
+from typing import Optional
 
 import requests
 from dotenv import load_dotenv
 
-from yutipy.exceptions import (
-    AuthenticationException,
-    InvalidValueException,
-    KKBoxException,
-)
+from yutipy.base_clients import BaseClient
+from yutipy.exceptions import InvalidValueException, KKBoxException
 from yutipy.logger import logger
 from yutipy.models import MusicInfo
 from yutipy.utils.helpers import are_strings_similar, is_valid_string
@@ -25,7 +20,7 @@ KKBOX_CLIENT_ID = os.getenv("KKBOX_CLIENT_ID")
 KKBOX_CLIENT_SECRET = os.getenv("KKBOX_CLIENT_SECRET")
 
 
-class KKBox:
+class KKBox(BaseClient):
     """
     A class to interact with KKBOX Open API.
 
@@ -61,207 +56,16 @@ class KKBox:
                 "Client Secret was not found. Set it in environment variable or directly pass it when creating object."
             )
 
-        self.defer_load = defer_load
+        super().__init__(
+            service_name="KKBox",
+            access_token_url="https://account.kkbox.com/oauth2/token",
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            defer_load=defer_load,
+        )
 
-        self._is_session_closed = False
-        self._normalize_non_english = True
+        self.__api_url = "https://api.kkbox.com/v1.1"
         self._valid_territories = ["HK", "JP", "MY", "SG", "TW"]
-
-        self.api_url = "https://api.kkbox.com/v1.1"
-        self.__access_token = None
-        self.__token_expires_in = None
-        self.__token_requested_at = None
-        self.__session = requests.Session()
-        self.__translation_session = requests.Session()
-
-        if not defer_load:
-            # Attempt to load access token during initialization if not deferred
-            token_info = None
-            try:
-                token_info = self.load_access_token()
-            except NotImplementedError:
-                logger.warning(
-                    "`load_access_token` is not implemented. Falling back to in-memory storage and requesting new access token."
-                )
-            finally:
-                if not token_info:
-                    token_info = self.__get_access_token()
-                self.__access_token = token_info.get("access_token")
-                self.__token_expires_in = token_info.get("expires_in")
-                self.__token_requested_at = token_info.get("requested_at")
-
-                try:
-                    self.save_access_token(token_info)
-                except NotImplementedError:
-                    logger.warning(
-                        "`save_access_token` is not implemented, falling back to in-memory storage. Access token will not be saved."
-                    )
-        else:
-            logger.warning(
-                "`defer_load` is set to `True`. Make sure to call `load_token_after_init()`."
-            )
-
-    def __enter__(self):
-        """Enters the runtime context related to this object."""
-        return self
-
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        """Exits the runtime context related to this object."""
-        self.close_session()
-
-    def close_session(self) -> None:
-        """Closes the current session."""
-        if not self.is_session_closed:
-            self.__session.close()
-            self.__translation_session.close()
-            self._is_session_closed = True
-
-    @property
-    def is_session_closed(self) -> bool:
-        """Checks if the session is closed."""
-        return self._is_session_closed
-
-    def load_token_after_init(self):
-        """
-        Explicitly load the access token after initialization.
-        This is useful when ``defer_load`` is set to ``True`` during initialization.
-        """
-        token_info = None
-        try:
-            token_info = self.load_access_token()
-        except NotImplementedError:
-            logger.warning(
-                "`load_access_token` is not implemented. Falling back to in-memory storage and requesting new access token."
-            )
-        finally:
-            if not token_info:
-                token_info = self.__get_access_token()
-            self.__access_token = token_info.get("access_token")
-            self.__token_expires_in = token_info.get("expires_in")
-            self.__token_requested_at = token_info.get("requested_at")
-
-            try:
-                self.save_access_token(token_info)
-            except NotImplementedError:
-                logger.warning(
-                    "`save_access_token` is not implemented, falling back to in-memory storage. Access token will not be saved."
-                )
-
-    def __authorization_header(self) -> dict:
-        """
-        Generates the authorization header for Spotify API requests.
-
-        Returns
-        -------
-        dict
-            A dictionary containing the Bearer token for authentication.
-        """
-        return {"Authorization": f"Bearer {self.__access_token}"}
-
-    def __get_access_token(self) -> dict:
-        """
-        Gets the KKBOX Open API access token information.
-
-        Returns
-        -------
-        str
-            The KKBOX Open API access token, with additional information such as expires in, etc.
-        """
-        auth_string = f"{self.client_id}:{self.client_secret}"
-        auth_base64 = base64.b64encode(auth_string.encode("utf-8")).decode("utf-8")
-
-        url = " https://account.kkbox.com/oauth2/token"
-        headers = {
-            "Authorization": f"Basic {auth_base64}",
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-        data = {"grant_type": "client_credentials"}
-
-        try:
-            logger.info("Authenticating with KKBOX Open API")
-            response = self.__session.post(
-                url=url, headers=headers, data=data, timeout=30
-            )
-            logger.debug(f"Authentication response status code: {response.status_code}")
-            response.raise_for_status()
-        except requests.RequestException as e:
-            logger.warning(f"Network error during KKBOX authentication: {e}")
-            return None
-
-        if response.status_code == 200:
-            response_json = response.json()
-            response_json["requested_at"] = time()
-            return response_json
-        else:
-            raise AuthenticationException(
-                f"Invalid response received: {response.json()}"
-            )
-
-    def __refresh_access_token(self):
-        """Refreshes the token if it has expired."""
-        if time() - self.__token_requested_at >= self.__token_expires_in:
-            token_info = self.__get_access_token()
-
-            try:
-                self.save_access_token(token_info)
-            except NotImplementedError as e:
-                logger.warning(e)
-
-            self.__access_token = token_info.get("access_token")
-            self.__token_expires_in = token_info.get("expires_in")
-            self.__token_requested_at = token_info.get("requested_at")
-
-        logger.info("The access token is still valid, no need to refresh.")
-
-    def save_access_token(self, token_info: dict) -> None:
-        """
-        Saves the access token and related information.
-
-        This method must be overridden in a subclass to persist the access token and other
-        related information (e.g., expiration time). If not implemented,
-        the access token will not be saved, and it will be requested each time the
-        application restarts.
-
-        Parameters
-        ----------
-        token_info : dict
-            A dictionary containing the access token and related information, such as
-            refresh token, expiration time, etc.
-
-        Raises
-        ------
-        NotImplementedError
-            If the method is not overridden in a subclass.
-        """
-        raise NotImplementedError(
-            "The `save_access_token` method must be overridden in a subclass to save the access token and related information. "
-            "If not implemented, access token information will not be persisted, and users will need to re-authenticate after application restarts."
-        )
-
-    def load_access_token(self) -> Union[dict, None]:
-        """
-        Loads the access token and related information.
-
-        This method must be overridden in a subclass to retrieve the access token and other
-        related information (e.g., expiration time) from persistent storage.
-        If not implemented, the access token will not be loaded, and it will be requested
-        each time the application restarts.
-
-        Returns
-        -------
-        dict | None
-            A dictionary containing the access token and related information, such as
-            refresh token, expiration time, etc., or None if no token is found.
-
-        Raises
-        ------
-        NotImplementedError
-            If the method is not overridden in a subclass.
-        """
-        raise NotImplementedError(
-            "The `load_access_token` method must be overridden in a subclass to load access token and related information. "
-            "If not implemented, access token information will not be loaded, and users will need to re-authenticate after application restarts."
-        )
 
     def search(
         self,
@@ -299,28 +103,24 @@ class KKBox:
             )
 
         self._normalize_non_english = normalize_non_english
-
-        self.__refresh_access_token()
+        self._refresh_access_token()
 
         query = (
             f"?q={artist} - {song}&type=track,album&territory={territory}&limit={limit}"
         )
-        query_url = f"{self.api_url}/search{query}"
+        query_url = f"{self.__api_url}/search{query}"
 
         logger.info(f"Searching KKBOX for `artist='{artist}'` and `song='{song}'`")
         logger.debug(f"Query URL: {query_url}")
 
         try:
-            response = self.__session.get(
-                query_url, headers=self.__authorization_header(), timeout=30
+            response = self._session.get(
+                query_url, headers=self._authorization_header(), timeout=30
             )
-            logger.debug(f"Parsing response JSON: {response.json()}")
             response.raise_for_status()
         except requests.RequestException as e:
+            logger.warning(f"Unexpected error while searching KKBox: {e}")
             return None
-
-        if response.status_code != 200:
-            raise KKBoxException(f"Failed to search for music: {response.json()}")
 
         return self._find_music_info(artist, song, response.json())
 
@@ -439,7 +239,7 @@ class KKBox:
             track["name"],
             song,
             use_translation=self._normalize_non_english,
-            translation_session=self.__translation_session,
+            translation_session=self._translation_session,
         ):
             return None
 
@@ -450,7 +250,7 @@ class KKBox:
                 artists_name,
                 artist,
                 use_translation=self._normalize_non_english,
-                translation_session=self.__translation_session,
+                translation_session=self._translation_session,
             )
             else None
         )
@@ -497,7 +297,7 @@ class KKBox:
             album["name"],
             song,
             use_translation=self._normalize_non_english,
-            translation_session=self.__translation_session,
+            translation_session=self._translation_session,
         ):
             return None
 
@@ -508,7 +308,7 @@ class KKBox:
                 artists_name,
                 artist,
                 use_translation=self._normalize_non_english,
-                translation_session=self.__translation_session,
+                translation_session=self._translation_session,
             )
             else None
         )
@@ -540,7 +340,7 @@ if __name__ == "__main__":
     from yutipy.logger import enable_logging
 
     enable_logging(level=logging.DEBUG)
-    kkbox = KKBox(KKBOX_CLIENT_ID, KKBOX_CLIENT_SECRET)
+    kkbox = KKBox()
 
     try:
         artist_name = input("Artist Name: ")

--- a/yutipy/lastfm.py
+++ b/yutipy/lastfm.py
@@ -1,7 +1,6 @@
 __all__ = ["LastFm", "LastFmException"]
 
 import os
-from dataclasses import asdict
 from time import time
 from pprint import pprint
 from typing import Optional

--- a/yutipy/musicyt.py
+++ b/yutipy/musicyt.py
@@ -79,12 +79,10 @@ class MusicYT:
         self.normalize_non_english = normalize_non_english
 
         query = f"{artist} - {song}"
-
-        logger.info(
-            f"Searching YouTube Music for `artist='{artist}'` and `song='{song}'`"
-        )
-
         try:
+            logger.info(
+                f"Searching YouTube Music for `artist='{artist}'` and `song='{song}'`"
+            )
             results = self.ytmusic.search(query=query, limit=limit)
         except exceptions.YTMusicServerError as e:
             logger.warning(f"Something went wrong while searching YTMusic: {e}")

--- a/yutipy/spotify.py
+++ b/yutipy/spotify.py
@@ -1,19 +1,15 @@
 __all__ = ["Spotify", "SpotifyException", "SpotifyAuthException"]
 
-import base64
 import os
-import secrets
 import webbrowser
 from pprint import pprint
-from time import time
 from typing import Optional, Union
-from urllib.parse import urlencode
 
 import requests
 from dotenv import load_dotenv
 
+from yutipy.base_clients import BaseAuthClient, BaseClient
 from yutipy.exceptions import (
-    AuthenticationException,
     InvalidValueException,
     SpotifyAuthException,
     SpotifyException,
@@ -34,7 +30,7 @@ SPOTIFY_CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
 SPOTIFY_REDIRECT_URI = os.getenv("SPOTIFY_REDIRECT_URI")
 
 
-class Spotify:
+class Spotify(BaseClient):
     """
     A class to interact with the Spotify API. It uses "Client Credentials" grant type (or flow).
 
@@ -55,9 +51,8 @@ class Spotify:
         client_secret : str, optional
             The Client secret for the Spotify API. Defaults to ``SPOTIFY_CLIENT_SECRET`` from environment variable or the ``.env`` file.
         defer_load : bool, optional
-            Whether to defer loading the access token during initialization. Default is ``False``.
+            Whether to defer loading the access token during initialization, by default ``False``
         """
-
         self.client_id = client_id or SPOTIFY_CLIENT_ID
         self.client_secret = client_secret or SPOTIFY_CLIENT_SECRET
 
@@ -71,224 +66,15 @@ class Spotify:
                 "Client Secret was not found. Set it in environment variable or directly pass it when creating object."
             )
 
-        self.defer_load = defer_load
-
-        self._is_session_closed = False
-        self._normalize_non_english = True
+        super().__init__(
+            service_name="Spotify",
+            access_token_url="https://accounts.spotify.com/api/token",
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            defer_load=defer_load,
+        )
 
         self.__api_url = "https://api.spotify.com/v1"
-        self.__access_token = None
-        self.__token_expires_in = None
-        self.__token_requested_at = None
-        self.__session = requests.Session()
-        self.__translation_session = requests.Session()
-
-        if not defer_load:
-            # Attempt to load access token during initialization if not deferred
-            token_info = None
-            try:
-                token_info = self.load_access_token()
-            except NotImplementedError:
-                logger.warning(
-                    "`load_access_token` is not implemented. Falling back to in-memory storage and requesting new access token."
-                )
-            finally:
-                if not token_info:
-                    token_info = self.__get_access_token()
-                self.__access_token = token_info.get("access_token")
-                self.__token_expires_in = token_info.get("expires_in")
-                self.__token_requested_at = token_info.get("requested_at")
-
-                try:
-                    self.save_access_token(token_info)
-                except NotImplementedError:
-                    logger.warning(
-                        "`save_access_token` is not implemented, falling back to in-memory storage. Access token will not be saved."
-                    )
-        else:
-            logger.warning(
-                "`defer_load` is set to `True`. Make sure to call `load_token_after_init()`."
-            )
-
-    def __enter__(self):
-        """Enters the runtime context related to this object."""
-        return self
-
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        """Exits the runtime context related to this object."""
-        self.close_session()
-
-    def close_session(self) -> None:
-        """Closes the current session(s)."""
-        if not self.is_session_closed:
-            self.__session.close()
-            self.__translation_session.close()
-            self._is_session_closed = True
-
-    @property
-    def is_session_closed(self) -> bool:
-        """Checks if the session is closed."""
-        return self._is_session_closed
-
-    def load_token_after_init(self):
-        """
-        Explicitly load the access token after initialization.
-        This is useful when ``defer_load`` is set to ``True`` during initialization.
-        """
-        token_info = None
-        try:
-            token_info = self.load_access_token()
-        except NotImplementedError:
-            logger.warning(
-                "`load_access_token` is not implemented. Falling back to in-memory storage and requesting new access token."
-            )
-        finally:
-            if not token_info:
-                token_info = self.__get_access_token()
-            self.__access_token = token_info.get("access_token")
-            self.__token_expires_in = token_info.get("expires_in")
-            self.__token_requested_at = token_info.get("requested_at")
-
-            try:
-                self.save_access_token(token_info)
-            except NotImplementedError:
-                logger.warning(
-                    "`save_access_token` is not implemented, falling back to in-memory storage. Access token will not be saved."
-                )
-
-    def __authorization_header(self) -> dict:
-        """
-        Generates the authorization header for Spotify API requests.
-
-        Returns
-        -------
-        dict
-            A dictionary containing the Bearer token for authentication.
-        """
-        return {"Authorization": f"Bearer {self.__access_token}"}
-
-    def __get_access_token(self) -> dict:
-        """
-        Gets the Spotify API access token information.
-
-        Returns
-        -------
-        dict
-            The Spotify API access token, with additional information such as expires in, etc.
-        """
-        auth_string = f"{self.client_id}:{self.client_secret}"
-        auth_base64 = base64.b64encode(auth_string.encode("utf-8")).decode("utf-8")
-
-        url = "https://accounts.spotify.com/api/token"
-        headers = {
-            "Authorization": f"Basic {auth_base64}",
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-        data = {"grant_type": "client_credentials"}
-
-        try:
-            logger.info(
-                "Authenticating with Spotify API using Client Credentials grant type."
-            )
-            response = self.__session.post(
-                url=url, headers=headers, data=data, timeout=30
-            )
-            logger.debug(f"Authentication response status code: {response.status_code}")
-            response.raise_for_status()
-        except requests.RequestException as e:
-            raise requests.RequestException(
-                f"Network error during Spotify authentication: {e}"
-            )
-
-        if response.status_code == 200:
-            response_json = response.json()
-            response_json["requested_at"] = time()
-            return response_json
-        else:
-            raise AuthenticationException(
-                f"Invalid response received: {response.json()}"
-            )
-
-    def __refresh_access_token(self):
-        """Refreshes the token if it has expired."""
-        if not self.__access_token:
-            raise SpotifyAuthException("No access token was found.")
-
-        try:
-            if time() - self.__token_requested_at >= self.__token_expires_in:
-                token_info = self.__get_access_token()
-
-                try:
-                    self.save_access_token(token_info)
-                except NotImplementedError as e:
-                    logger.warning(e)
-
-                self.__access_token = token_info.get("access_token")
-                self.__token_expires_in = token_info.get("expires_in")
-                self.__token_requested_at = token_info.get("requested_at")
-
-            logger.info("The access token is still valid, no need to refresh.")
-        except (AuthenticationException, requests.RequestException) as e:
-            logger.warning(
-                f"Failed to refresh the access toke due to following error: {e}"
-            )
-        except TypeError:
-            logger.debug(
-                f"token requested at: {self.__token_requested_at} | token expires in: {self.__token_expires_in}"
-            )
-            logger.info(
-                "Something went wrong while trying to refresh the access token. Set logging level to `DEBUG` to see the issue."
-            )
-
-    def save_access_token(self, token_info: dict) -> None:
-        """
-        Saves the access token and related information.
-
-        This method must be overridden in a subclass to persist the access token and other
-        related information (e.g., expiration time). If not implemented,
-        the access token will not be saved, and it will be requested each time the
-        application restarts.
-
-        Parameters
-        ----------
-        token_info : dict
-            A dictionary containing the access token and related information, such as
-            refresh token, expiration time, etc.
-
-        Raises
-        ------
-        NotImplementedError
-            If the method is not overridden in a subclass.
-        """
-        raise NotImplementedError(
-            "The `save_access_token` method must be overridden in a subclass to save the access token and related information. "
-            "If not implemented, access token information will not be persisted, and users will need to re-authenticate after application restarts."
-        )
-
-    def load_access_token(self) -> Union[dict, None]:
-        """
-        Loads the access token and related information.
-
-        This method must be overridden in a subclass to retrieve the access token and other
-        related information (e.g., expiration time) from persistent storage.
-        If not implemented, the access token will not be loaded, and it will be requested
-        each time the application restarts.
-
-        Returns
-        -------
-        dict | None
-            A dictionary containing the access token and related information, such as
-            refresh token, expiration time, etc., or None if no token is found.
-
-        Raises
-        ------
-        NotImplementedError
-            If the method is not overridden in a subclass.
-        """
-        raise NotImplementedError(
-            "The `load_access_token` method must be overridden in a subclass to load access token and related information. "
-            "If not implemented, access token information will not be loaded, and users will need to re-authenticate after application restarts."
-        )
 
     def search(
         self,
@@ -334,7 +120,7 @@ class Spotify:
             if music_info:
                 return music_info
 
-            self.__refresh_access_token()
+            self._refresh_access_token()
 
             query_url = f"{self.__api_url}/search{query}"
 
@@ -344,16 +130,13 @@ class Spotify:
             logger.debug(f"Query URL: {query_url}")
 
             try:
-                response = self.__session.get(
-                    query_url, headers=self.__authorization_header(), timeout=30
+                response = self._session.get(
+                    query_url, headers=self._authorization_header(), timeout=30
                 )
                 response.raise_for_status()
             except requests.RequestException as e:
-                logger.warning(f"Network error during Spotify search: {e}")
+                logger.warning(f"Failed to search for music: {response.json()}")
                 return None
-
-            if response.status_code != 200:
-                raise SpotifyException(f"Failed to search for music: {response.json()}")
 
             artist_ids = artist_ids if artist_ids else self._get_artists_ids(artist)
             music_info = self._find_music_info(
@@ -400,8 +183,7 @@ class Spotify:
             )
 
         self._normalize_non_english = normalize_non_english
-
-        self.__refresh_access_token()
+        self._refresh_access_token()
 
         if isrc:
             query = f"?q={artist} {song} isrc:{isrc}&type=track&limit={limit}"
@@ -412,18 +194,15 @@ class Spotify:
 
         query_url = f"{self.__api_url}/search{query}"
         try:
-            response = self.__session.get(
-                query_url, headers=self.__authorization_header(), timeout=30
+            response = self._session.get(
+                query_url, headers=self._authorization_header(), timeout=30
             )
             response.raise_for_status()
         except requests.RequestException as e:
-            logger.warning(f"Network error during Spotify search (advanced): {e}")
-            return None
-
-        if response.status_code != 200:
-            raise SpotifyException(
+            raise logger.warning(
                 f"Failed to search music with ISRC/UPC: {response.json()}"
             )
+            return None
 
         artist_ids = self._get_artists_ids(artist)
         return self._find_music_info(artist, song, response.json(), artist_ids)
@@ -446,8 +225,8 @@ class Spotify:
         for name in separate_artists(artist):
             query_url = f"{self.__api_url}/search?q={name}&type=artist&limit=5"
             try:
-                response = self.__session.get(
-                    query_url, headers=self.__authorization_header(), timeout=30
+                response = self._session.get(
+                    query_url, headers=self._authorization_header(), timeout=30
                 )
                 response.raise_for_status()
             except requests.RequestException as e:
@@ -531,7 +310,7 @@ class Spotify:
             track["name"],
             song,
             use_translation=self._normalize_non_english,
-            translation_session=self.__translation_session,
+            translation_session=self._translation_session,
         ):
             return None
 
@@ -543,7 +322,7 @@ class Spotify:
                 x["name"],
                 artist,
                 use_translation=self._normalize_non_english,
-                translation_session=self.__translation_session,
+                translation_session=self._translation_session,
             )
             or x["id"] in artist_ids
         ]
@@ -594,7 +373,7 @@ class Spotify:
             album["name"],
             song,
             use_translation=self._normalize_non_english,
-            translation_session=self.__translation_session,
+            translation_session=self._translation_session,
         ):
             return None
 
@@ -606,7 +385,7 @@ class Spotify:
                 x["name"],
                 artist,
                 use_translation=self._normalize_non_english,
-                translation_session=self.__translation_session,
+                translation_session=self._translation_session,
             )
             or x["id"] in artist_ids
         ]
@@ -637,7 +416,7 @@ class Spotify:
         return None
 
 
-class SpotifyAuth:
+class SpotifyAuth(BaseAuthClient):
     """
     A class to interact with the Spotify API. It uses "Authorization Code" grant type (or flow).
 
@@ -673,6 +452,7 @@ class SpotifyAuth:
         self.client_id = client_id or os.getenv("SPOTIFY_CLIENT_ID")
         self.client_secret = client_secret or os.getenv("SPOTIFY_CLIENT_SECRET")
         self.redirect_uri = redirect_uri or os.getenv("SPOTIFY_REDIRECT_URI")
+        self.scopes = scopes
 
         if not self.client_id:
             raise SpotifyAuthException(
@@ -689,366 +469,25 @@ class SpotifyAuth:
                 "No redirect URI was provided! Set it in environment variable or directly pass it when creating object."
             )
 
-        self.scope = scopes
-        self.defer_load = defer_load
-
-        self._is_session_closed = False
-
-        self.__api_url = "https://api.spotify.com/v1/me"
-        self.__access_token = None
-        self.__refresh_token = None
-        self.__token_expires_in = None
-        self.__token_requested_at = None
-        self.__session = requests.Session()
-
         if not scopes:
             logger.warning(
                 "No scopes were provided. Authorization will only grant access to publicly available information."
             )
-            self.scope = None
         else:
-            self.scope = " ".join(scopes)
+            self.scopes = " ".join(scopes)
 
-        if not defer_load:
-            # Attempt to load access token during initialization if not deferred
-            try:
-                token_info = self.load_access_token()
-                if token_info:
-                    self.__access_token = token_info.get("access_token")
-                    self.__refresh_token = token_info.get("refresh_token")
-                    self.__token_expires_in = token_info.get("expires_in")
-                    self.__token_requested_at = token_info.get("requested_at")
-                else:
-                    logger.warning(
-                        "No access token found during initialization. You must authenticate to obtain a new token."
-                    )
-            except NotImplementedError:
-                logger.warning(
-                    "`load_access_token` is not implemented. Falling back to in-memory storage."
-                )
-        else:
-            logger.warning(
-                "`defer_load` is set to `True`. Make sure to call `load_token_after_init()`."
-            )
-
-    def __enter__(self):
-        """Enters the runtime context related to this object."""
-        return self
-
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        """Exits the runtime context related to this object."""
-        self.close_session()
-
-    def close_session(self) -> None:
-        """Closes the current session(s)."""
-        if not self.is_session_closed:
-            self.__session.close()
-            self._is_session_closed = True
-
-    @property
-    def is_session_closed(self) -> bool:
-        """Checks if the session is closed."""
-        return self._is_session_closed
-
-    def load_token_after_init(self):
-        """
-        Explicitly load the access token after initialization.
-        This is useful when ``defer_load`` is set to ``True`` during initialization.
-        """
-        try:
-            token_info = self.load_access_token()
-            if token_info:
-                self.__access_token = token_info.get("access_token")
-                self.__refresh_token = token_info.get("refresh_token")
-                self.__token_expires_in = token_info.get("expires_in")
-                self.__token_requested_at = token_info.get("requested_at")
-            else:
-                logger.warning(
-                    "No access token found. You must authenticate to obtain a new token."
-                )
-        except NotImplementedError:
-            logger.warning(
-                "`load_access_token` is not implemented. Falling back to in-memory storage."
-            )
-
-    def __authorization_header(self) -> dict:
-        """
-        Generates the authorization header for Spotify API requests.
-
-        Returns
-        -------
-        dict
-            A dictionary containing the Bearer token for authentication.
-        """
-        return {"Authorization": f"Bearer {self.__access_token}"}
-
-    def __get_access_token(
-        self,
-        authorization_code: str = None,
-        refresh_token: str = None,
-    ) -> dict:
-        """
-        Gets the Spotify API access token information.
-
-        If ``authorization_code`` provided, it will try to get a new access token from Spotify.
-        Otherwise, if `refresh_token` is provided, it will refresh the access token using it
-        and return new access token information.
-
-        Returns
-        -------
-        dict
-            The Spotify API access token, with additional information such as expires in, refresh token, etc.
-        """
-        auth_string = f"{self.client_id}:{self.client_secret}"
-        auth_base64 = base64.b64encode(auth_string.encode("utf-8")).decode("utf-8")
-
-        url = "https://accounts.spotify.com/api/token"
-        headers = {
-            "Authorization": f"Basic {auth_base64}",
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-
-        if authorization_code:
-            data = {
-                "grant_type": "authorization_code",
-                "code": authorization_code,
-                "redirect_uri": self.redirect_uri,
-            }
-
-        if refresh_token:
-            data = {
-                "grant_type": "refresh_token",
-                "refresh_token": self.__refresh_token,
-            }
-
-        try:
-            logger.info(
-                "Authenticating with Spotify API using Authorization Code grant type."
-            )
-            response = self.__session.post(
-                url=url, headers=headers, data=data, timeout=30
-            )
-            logger.debug(f"Authentication response status code: {response.status_code}")
-            response.raise_for_status()
-        except requests.RequestException as e:
-            raise requests.RequestException(
-                f"Network error during Spotify authentication: {e}"
-            )
-
-        if response.status_code == 200:
-            response_json = response.json()
-            response_json["requested_at"] = time()
-            return response_json
-        else:
-            raise AuthenticationException(
-                f"Invalid response received: {response.json()}"
-            )
-
-    def __refresh_access_token(self):
-        """Refreshes the token if it has expired."""
-        if not self.__access_token:
-            raise SpotifyAuthException("No access token was found.")
-
-        try:
-            if time() - self.__token_requested_at >= self.__token_expires_in:
-                token_info = self.__get_access_token(refresh_token=self.__refresh_token)
-
-                try:
-                    self.save_access_token(token_info)
-                except NotImplementedError as e:
-                    logger.warning(e)
-
-                self.__access_token = token_info.get("access_token")
-                self.__refresh_token = token_info.get("refresh_token")
-                self.__token_expires_in = token_info.get("expires_in")
-                self.__token_requested_at = token_info.get("requested_at")
-
-            logger.info("The access token is still valid, no need to refresh.")
-        except (AuthenticationException, requests.RequestException) as e:
-            logger.warning(f"Failed to refresh the access toke due to following error: {e}")
-        except TypeError:
-            logger.debug(
-                f"token requested at: {self.__token_requested_at} | token expires in: {self.__token_expires_in}"
-            )
-            logger.warning(
-                "Something went wrong while trying to refresh the access token. Set logging level to `DEBUG` to see the issue."
-            )
-
-    @staticmethod
-    def generate_state() -> str:
-        """
-        Generates a random state string for use in OAuth 2.0 authorization.
-
-        This method creates a cryptographically secure, URL-safe string that can be used
-        to prevent cross-site request forgery (CSRF) attacks during the authorization process.
-
-        Returns
-        -------
-        str
-            A random URL-safe string to be used as the state parameter in OAuth 2.0.
-        """
-        return secrets.token_urlsafe(16)
-
-    def get_authorization_url(self, state: str = None, show_dialog: bool = False):
-        """
-        Constructs the Spotify authorization URL for user authentication.
-
-        This method generates a URL that can be used to redirect users to Spotify's
-        authorization page for user authentication.
-
-        Parameters
-        ----------
-        state : str, optional
-            A random string to maintain state between the request and callback.
-            If not provided, no state parameter is included.
-
-            You may use :meth:`SpotifyAuth.generate_state` method to generate one.
-        show_dialog : bool, optional
-            Whether or not to force the user to approve the app again if they’ve already done so.
-            If ``False`` (default), a user who has already approved the application may be automatically
-            redirected to the URI specified by redirect_uri. If ``True``, the user will not be automatically
-            redirected and will have to approve the app again.
-
-        Returns
-        -------
-        str
-            The full authorization URL to redirect users for Spotify authentication.
-        """
-        auth_endpoint = "https://accounts.spotify.com/authorize"
-        payload = {
-            "response_type": "code",
-            "client_id": self.client_id,
-            "redirect_uri": self.redirect_uri,
-            "show_dialog": show_dialog,
-        }
-
-        if self.scope:
-            payload["scope"] = self.scope
-
-        if state:
-            payload["state"] = state
-
-        return f"{auth_endpoint}?{urlencode(payload)}"
-
-    def save_access_token(self, token_info: dict) -> None:
-        """
-        Saves the access token and related information.
-
-        This method must be overridden in a subclass to persist the access token and other
-        related information (e.g., refresh token, expiration time). If not implemented,
-        the access token will not be saved, and users will need to re-authenticate after
-        application restarts.
-
-        Parameters
-        ----------
-        token_info : dict
-            A dictionary containing the access token and related information, such as
-            refresh token, expiration time, etc.
-
-        Raises
-        ------
-        NotImplementedError
-            If the method is not overridden in a subclass.
-        """
-        raise NotImplementedError(
-            "The `save_access_token` method must be overridden in a subclass to save the access token and related information. "
-            "If not implemented, access token information will not be persisted, and users will need to re-authenticate after application restarts."
+        super().__init__(
+            service_name="Spotify",
+            access_token_url="https://accounts.spotify.com/api/token",
+            user_auth_url="https://accounts.spotify.com/authorize",
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            redirect_uri=self.redirect_uri,
+            scopes=self.scopes,
+            defer_load=defer_load,
         )
 
-    def load_access_token(self) -> Union[dict, None]:
-        """
-        Loads the access token and related information.
-
-        This method must be overridden in a subclass to retrieve the access token and other
-        related information (e.g., refresh token, expiration time) from persistent storage.
-        If not implemented, the access token will not be loaded, and users will need to
-        re-authenticate after application restarts.
-
-        Returns
-        -------
-        dict | None
-            A dictionary containing the access token and related information, such as
-            refresh token, expiration time, etc., or None if no token is found.
-
-        Raises
-        ------
-        NotImplementedError
-            If the method is not overridden in a subclass.
-        """
-        raise NotImplementedError(
-            "The `load_access_token` method must be overridden in a subclass to load access token and related information. "
-            "If not implemented, access token information will not be loaded, and users will need to re-authenticate after application restarts."
-        )
-
-    def callback_handler(self, code, state, expected_state):
-        """
-        Handles the callback phase of the OAuth 2.0 authorization process.
-
-        This method processes the authorization code and state returned by Spotify after the user
-        has granted permission. It validates the state to prevent CSRF attacks, exchanges the
-        authorization code for an access token, and saves the token for future use.
-
-        Parameters
-        ----------
-        code : str
-            The authorization code returned by Spotify after user authorization.
-        state : str
-            The state parameter returned by Spotify to ensure the request's integrity.
-        expected_state : str
-            The original state parameter sent during the authorization request, used to validate the response.
-
-        Raises
-        ------
-        SpotifyAuthException
-            If the returned state does not match the expected state.
-
-        Notes
-        -----
-        - This method can be used in a web application (e.g., Flask) in the `/callback` route to handle
-          successful authorization.
-        - Ensure that the ``save_access_token`` and ``load_access_token`` methods are implemented in a subclass
-          if token persistence is required.
-
-        Example
-        -------
-        In a Flask application, you can use this method in the ``/callback`` route:
-
-        .. code-block:: python
-
-            @app.route('/callback')
-            def callback():
-                code = request.args.get('code')
-                state = request.args.get('state')
-                expected_state = session['state']  # Retrieve the state stored during authorization URL generation
-
-                try:
-                    spotify_auth.callback_handler(code, state, expected_state)
-                    return "Authorization successful!"
-                except SpotifyAuthException as e:
-                    return f"Authorization failed: {e}", 400
-        """
-        if state != expected_state:
-            raise SpotifyAuthException("state does not match!")
-
-        token_info = None
-
-        try:
-            token_info = self.load_access_token()
-        except NotImplementedError as e:
-            logger.warning(e)
-
-        if not token_info:
-            token_info = self.__get_access_token(authorization_code=code)
-
-        self.__access_token = token_info.get("access_token")
-        self.__refresh_token = token_info.get("refresh_token")
-        self.__token_expires_in = token_info.get("expires_in")
-        self.__token_requested_at = token_info.get("requested_at")
-
-        try:
-            self.save_access_token(token_info)
-        except NotImplementedError as e:
-            logger.warning(e)
+        self.__api_url = "https://api.spotify.com/v1/me"
 
     def get_user_profile(self) -> Optional[dict]:
         """
@@ -1063,19 +502,11 @@ class SpotifyAuth:
         dict
             A dictionary containing the user's display name and profile images.
         """
-        try:
-            self.__refresh_access_token()
-        except SpotifyAuthException:
-            logger.warning(
-                "No access token was found. You may authenticate the user again."
-            )
-            return None
-
         query_url = self.__api_url
-        header = self.__authorization_header()
+        header = self._authorization_header()
 
         try:
-            response = self.__session.get(query_url, headers=header, timeout=30)
+            response = self._session.get(query_url, headers=header, timeout=30)
             response.raise_for_status()
         except requests.RequestException as e:
             logger.warning(f"Failed to fetch user profile: {e}")
@@ -1089,7 +520,7 @@ class SpotifyAuth:
         return {
             "display_name": result.get("display_name"),
             "images": result.get("images", []),
-            "url": result.get("external_urls", {}).get("spotify")
+            "url": result.get("external_urls", {}).get("spotify"),
         }
 
     def get_currently_playing(self) -> Optional[UserPlaying]:
@@ -1113,19 +544,11 @@ class SpotifyAuth:
         - If the API response does not contain the expected data, the method will return `None`.
 
         """
-        try:
-            self.__refresh_access_token()
-        except SpotifyAuthException:
-            logger.warning(
-                "No access token was found. You may authenticate the user again."
-            )
-            return None
-
         query_url = f"{self.__api_url}/player/currently-playing"
-        header = self.__authorization_header()
+        header = self._authorization_header()
 
         try:
-            response = self.__session.get(query_url, headers=header, timeout=30)
+            response = self._session.get(query_url, headers=header, timeout=30)
             response.raise_for_status()
         except requests.RequestException as e:
             logger.warning(f"Error while getting Spotify user activity: {e}")
@@ -1133,14 +556,6 @@ class SpotifyAuth:
 
         if response.status_code == 204:
             logger.info("Requested user is currently not listening to any music.")
-            return None
-        if response.status_code != 200:
-            try:
-                logger.warning(f"Unexpected response: {response.json()}")
-            except requests.exceptions.JSONDecodeError:
-                logger.warning(
-                    f"Response Code: {response.status_code}, Reason: {response.reason}"
-                )
             return None
 
         response_json = response.json()
@@ -1194,7 +609,7 @@ if __name__ == "__main__":
     choice = input("\nEnter your choice (1 or 2): ")
 
     if choice == "1":
-        spotify = Spotify(SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET)
+        spotify = Spotify()
 
         try:
             artist_name = input("Artist Name: ")
@@ -1208,12 +623,7 @@ if __name__ == "__main__":
         redirect_uri = input("Enter Redirect URI: ")
         scopes = ["user-read-email", "user-read-private"]
 
-        spotify_auth = SpotifyAuth(
-            client_id=SPOTIFY_CLIENT_ID,
-            client_secret=SPOTIFY_CLIENT_SECRET,
-            redirect_uri=redirect_uri,
-            scopes=scopes,
-        )
+        spotify_auth = SpotifyAuth(scopes=scopes)
 
         try:
             state = spotify_auth.generate_state()


### PR DESCRIPTION
- Base Clients for "Client Credentials" & "Authorization Code" grant type/flow.
- Using Base Clients to avoid duplicating same logic across the library and making it easier to maintain the project.
- Update tests to reflect rename/change in internal variables.
- Only raise exception in methods dealing with authentication.
- For search methods, return `None` if something goes wrong and log the appropriate message instead of raising an exception.