### PR TITLE
Only Raise Exception if `token_info` is not `None`

### DIFF
--- a/yutipy/base_clients.py
+++ b/yutipy/base_clients.py
@@ -87,7 +87,7 @@ class BaseClient:
         token_info = None
         try:
             token_info = self.load_access_token()
-            if not isinstance(token_info, dict):
+            if token_info and not isinstance(token_info, dict):
                 raise InvalidValueException(
                     "`load_access_token()` should return a dict."
                 )
@@ -316,7 +316,7 @@ class BaseAuthClient:
         token_info = None
         try:
             token_info = self.load_access_token()
-            if not isinstance(token_info, dict):
+            if token_info and not isinstance(token_info, dict):
                 raise InvalidValueException(
                     "`load_access_token()` should return a dict."
                 )


### PR DESCRIPTION
Otherwise it was raising error during initialization as `load_access_token()` (if implemented) is expected to return `None` as there might be no token info saved before.