### PR TITLE
Normalize Strings Before Translation and Cache Translations in Memory (faster response time)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,4 @@
 include LICENSE
 include README.md
 include requirements.txt
-include requirements-dev.txt
 recursive-include yutipy *
-recursive-include tests *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,6 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 
-[project.optional-dependencies]
-dev =  [
-    "pytest",
-]
-
 [project.urls]
 Homepage = "https://github.com/CheapNightbot/yutipy"
 Documentation = "https://yutipy.readthedocs.io/"

--- a/yutipy/base_clients.py
+++ b/yutipy/base_clients.py
@@ -172,7 +172,7 @@ class BaseClient:
                 self._token_expires_in = token_info.get("expires_in")
                 self._token_requested_at = token_info.get("requested_at")
             else:
-                logger.info("The access token is still valid, no need to refresh.")
+                logger.debug("The access token is still valid, no need to refresh.")
         except TypeError:
             logger.debug(
                 f"token requested at: {self._token_requested_at} | token expires in: {self._token_expires_in}"
@@ -419,7 +419,7 @@ class BaseAuthClient:
                 self._token_requested_at = token_info.get("requested_at")
 
             else:
-                logger.info("The access token is still valid, no need to refresh.")
+                logger.debug("The access token is still valid, no need to refresh.")
         except TypeError:
             logger.debug(
                 f"token requested at: {self._token_requested_at} | token expires in: {self._token_expires_in}"

--- a/yutipy/deezer.py
+++ b/yutipy/deezer.py
@@ -95,7 +95,7 @@ class Deezer:
                 return None
 
             try:
-                logger.debug(f"Parsing response JSON: {response.json()}")
+                logger.debug(f"Parsing response JSON.")
                 result = response.json()["data"]
             except (IndexError, KeyError, ValueError) as e:
                 logger.warning(f"Invalid response structure from Deezer: {e}")
@@ -159,7 +159,7 @@ class Deezer:
             return None
 
         try:
-            logger.debug(f"Response JSON: {response.json()}")
+            logger.debug(f"Parsing Response JSON.")
             result = response.json()
         except ValueError as e:
             logger.warning(f"Invalid response received from Deezer: {e}")

--- a/yutipy/itunes.py
+++ b/yutipy/itunes.py
@@ -95,7 +95,7 @@ class Itunes:
                 return None
 
             try:
-                logger.debug(f"Parsing response JSON: {response.json()}")
+                logger.debug(f"Parsing response JSON.")
                 result = response.json()["results"]
             except (IndexError, KeyError, ValueError) as e:
                 logger.warning(f"Invalid response structure from iTunes: {e}")

--- a/yutipy/utils/helpers.py
+++ b/yutipy/utils/helpers.py
@@ -8,6 +8,11 @@ kakasi = pykakasi.kakasi()
 TRANSLATION_CACHE = {}
 
 
+def similarity(str1: str, str2: str, threshold: int = 80):
+    similarity_score = fuzz.WRatio(str1, str2, processor=default_process)
+    return similarity_score > threshold
+
+
 def translate_text(
     text: str,
     sl: str = None,
@@ -79,35 +84,90 @@ def are_strings_similar(
     """
     global TRANSLATION_CACHE
 
-    # Use transliterated strings for comparison
-    str1 = "".join(item["hepburn"] for item in kakasi.convert(str1)) or str1
-    str2 = "".join(item["hepburn"] for item in kakasi.convert(str2)) or str2
+    """
+    note for myself so that it make sense later ~ _(:з)∠)_
+    0. Check cached strings for comparision
+        a. if found and same, return True.
+    1. normalize original strings.
+        a. if both same, return True.
+    2. translate original string.
+        a. if both same, return True.
+    3. translate normalized string.
+        a. if both same, return True.
+    4. return False.
+    """
+
+    # ### Step 0 ####
+    cached_str1 = TRANSLATION_CACHE.get(str1, str1)
+    cached_str2 = TRANSLATION_CACHE.get(str2, str2)
+    similar = similarity(cached_str1, cached_str2, threshold=threshold)
+    if similar:
+        return True
+    # ###############
+
+    # ### Step 1 ####
+    # Transliterate / Normalize Strings
+    normalized_str1 = (
+        TRANSLATION_CACHE.get(str1)
+        or "".join(item["hepburn"] for item in kakasi.convert(str1))
+        or str1
+    )
+    normalized_str2 = (
+        TRANSLATION_CACHE.get(str2)
+        or "".join(item["hepburn"] for item in kakasi.convert(str2))
+        or str2
+    )
+    similar = similarity(normalized_str1, normalized_str2, threshold=threshold)
+    if similar:
+        TRANSLATION_CACHE[str1] = normalized_str1
+        TRANSLATION_CACHE[str2] = normalized_str2
+        return True
+    # ###############
 
     if use_translation:
-        translated_str1 = (
+        # ### Step 2 ####
+        original_translated_str1 = (
             TRANSLATION_CACHE.get(str1)
             or translate_text(str1, session=translation_session)["destination-text"]
             if translation_session
             else translate_text(str1)["destination-text"]
         )
-        TRANSLATION_CACHE[str1] = translated_str1
-
-        translated_str2 = (
+        original_translated_str2 = (
             TRANSLATION_CACHE.get(str2)
             or translate_text(str2, session=translation_session)["destination-text"]
             if translation_session
             else translate_text(str2)["destination-text"]
         )
-        TRANSLATION_CACHE[str2] = translated_str2
-
-        similarity_score = fuzz.WRatio(
-            translated_str1, translated_str2, processor=default_process
+        similar = similarity(
+            original_translated_str1, original_translated_str2, threshold=threshold
         )
-        if similarity_score > threshold:
+        if similar:
+            TRANSLATION_CACHE[str1] = original_translated_str1
+            TRANSLATION_CACHE[str2] = original_translated_str2
+            return True
+        # ###############
+
+        normalized_translated_str1 = (
+            TRANSLATION_CACHE.get(str1)
+            or translate_text(str1, session=translation_session)["destination-text"]
+            if translation_session
+            else translation_session(str1)["destination-text"]
+        )
+        normalized_translated_str2 = (
+            TRANSLATION_CACHE.get(str2)
+            or translate_text(str2, session=translation_session)["destination-text"]
+            if translation_session
+            else translate_text(str2)["destination-text"]
+        )
+        similar = similarity(
+            normalized_translated_str1, normalized_translated_str2, threshold=threshold
+        )
+        if similar:
+            TRANSLATION_CACHE[str1] = normalized_translated_str1
+            TRANSLATION_CACHE[str2] = normalized_translated_str2
             return True
 
-    similarity_score = fuzz.WRatio(str1, str2, processor=default_process)
-    return similarity_score > threshold
+    return False
 
 
 def separate_artists(artists: str, custom_separator: str = None) -> list[str]:
@@ -147,3 +207,8 @@ def guess_album_type(total_tracks: int):
         return "ep"
     if total_tracks >= 7:
         return "album"
+
+
+if __name__ == "__main__":
+    result = are_strings_similar("ポーター", "Porter")
+    print(result)

--- a/yutipy/utils/helpers.py
+++ b/yutipy/utils/helpers.py
@@ -82,7 +82,6 @@ def are_strings_similar(
     Returns:
         bool: True if the strings are similar, otherwise False.
     """
-    global TRANSLATION_CACHE
 
     """
     note for myself so that it make sense later ~ _(:з)∠)_
@@ -207,8 +206,3 @@ def guess_album_type(total_tracks: int):
         return "ep"
     if total_tracks >= 7:
         return "album"
-
-
-if __name__ == "__main__":
-    result = are_strings_similar("ポーター", "Porter")
-    print(result)


### PR DESCRIPTION
- A string once translated, is going to have the same translation again no matter what (except language grammar and stuff changes XD), so it makes no sense to translate same string again and again.
- Since we can't save translations permanently for various reasons.. but at least can save them in memory.
- Will definitely improve the response time as we will not be having multiple calls to the translation API.